### PR TITLE
[codex] update family travel maps

### DIFF
--- a/travels/cherry-map.html
+++ b/travels/cherry-map.html
@@ -223,7 +223,19 @@
       {
         name: '苏州', lat: 31.2983, lng: 120.5832,
         country: '中国', firstVisitDate: '',
-        notes: '旅行',
+        notes: '旅行；2026年6月一家三口和爷爷奶奶旅行',
+        category: 'domestic'
+      },
+      {
+        name: '长沙', lat: 28.2282, lng: 112.9388,
+        country: '中国', firstVisitDate: '2026-07',
+        notes: '一家三口2026年7月旅行',
+        category: 'domestic'
+      },
+      {
+        name: '重庆', lat: 29.5630, lng: 106.5516,
+        country: '中国', firstVisitDate: '2026-07',
+        notes: '一家三口2026年7月旅行',
         category: 'domestic'
       },
       {

--- a/travels/dad-map.html
+++ b/travels/dad-map.html
@@ -135,7 +135,7 @@
       {
         name: '苏州', lat: 31.2983, lng: 120.5832,
         country: '中国', firstVisitDate: '',
-        notes: '保险公司苏沪杭三日游',
+        notes: '保险公司苏沪杭三日游；2026年6月一家三口和爷爷奶奶旅行',
         category: 'travel'
       },
       {

--- a/travels/daughter-map.html
+++ b/travels/daughter-map.html
@@ -181,7 +181,19 @@
       {
         name: '苏州', lat: 31.2983, lng: 120.5832,
         country: '中国', firstVisitDate: '',
-        notes: '旅行',
+        notes: '旅行；2026年6月一家三口和爷爷奶奶旅行',
+        category: 'domestic'
+      },
+      {
+        name: '长沙', lat: 28.2282, lng: 112.9388,
+        country: '中国', firstVisitDate: '2026-07',
+        notes: '一家三口2026年7月旅行',
+        category: 'domestic'
+      },
+      {
+        name: '重庆', lat: 29.5630, lng: 106.5516,
+        country: '中国', firstVisitDate: '2026-07',
+        notes: '一家三口2026年7月旅行',
         category: 'domestic'
       }
     ];

--- a/travels/mom-map.html
+++ b/travels/mom-map.html
@@ -156,6 +156,12 @@
         category: 'travel'
       },
       {
+        name: '苏州', lat: 31.2983, lng: 120.5832,
+        country: '中国', firstVisitDate: '2026-06',
+        notes: '一家三口和爷爷奶奶旅行',
+        category: 'travel'
+      },
+      {
         name: '临沂', lat: 35.1043, lng: 118.3565,
         country: '中国', firstVisitDate: '',
         notes: '蒙山旅行',


### PR DESCRIPTION
## Summary

- Update Cherry and daughter travel maps with the 2026-06 Suzhou family trip with grandparents.
- Add the 2026-07 Changsha and Chongqing trip only to Cherry and daughter maps.
- Add/update the grandparents' Suzhou records without adding the July Changsha/Chongqing trip to their maps.

## Validation

- `git diff --cached --check`
- Parsed embedded JavaScript in the four updated HTML map pages with Node.js.