### PR TITLE
fix GitHub Pages and metrics failures

### DIFF
--- a/.github/workflows/github-metrics.yaml
+++ b/.github/workflows/github-metrics.yaml
@@ -20,6 +20,9 @@ jobs:
           template: classic
           base: header
           config_timezone: Asia/Shanghai
+          retries: 3
+          retries_delay: 60
+          plugins_errors_fatal: yes
           plugin_followup: yes
           plugin_followup_sections: user
           plugin_notable: yes


### PR DESCRIPTION
## Summary

- Add retries for the lowlighter/metrics render step.
- Treat metrics plugin failures as fatal so a transient GitHub GraphQL 502 does not get committed into `github-metrics.svg` as `Unexpected error`.
- Rename backup Markdown files whose paths contained `:` so GitHub Pages/Jekyll does not treat the filename prefix as an invalid URI scheme.

## Why

The `plugin_notable` section can hit intermittent `502 Bad Gateway` responses from `https://api.github.com/graphql`. The workflow previously succeeded and committed the generated SVG with the plugin error embedded.

GitHub Pages also failed with `Invalid scheme format: '15_Add.a.link.to.https'` because a tracked backup file path contained `https:` in the filename: `BACKUP/15_Add.a.link.to.https:--github.com-pacoxu-talks-blob-main-README_zh.md.md`. Other backup filenames also contained colons, so this removes all tracked `:` paths to avoid the next Pages failure.

## Validation

- Ran `git diff --cached --check` before committing.
- Verified `git ls-files` no longer reports tracked paths containing `:`.
- Local environment does not have `jekyll` installed, so I could not run the full GitHub Pages build locally.