### PR TITLE
Refine Paco's childhood travel history

### DIFF
--- a/travels/map.html
+++ b/travels/map.html
@@ -165,8 +165,8 @@
       },
       {
         name: '济南', lat: 36.6512, lng: 117.1201,
-        country: '中国', firstVisitDate: '1999',
-        notes: '自主招生考试 + 多次旅行：大明湖/趵突泉',
+        country: '中国', firstVisitDate: '1998',
+        notes: '1998年小学时游趵突泉；自主招生考试等多次到访：大明湖/趵突泉',
         category: 'domestic'
       },
       {
@@ -273,8 +273,8 @@
       },
       {
         name: '泰安', lat: 36.2045, lng: 117.0870,
-        country: '中国', firstVisitDate: '1999',
-        notes: '泰山/岱庙旅行',
+        country: '中国', firstVisitDate: '约1997',
+        notes: '约1997年游泰山/岱庙',
         category: 'domestic'
       },
       {
@@ -285,14 +285,14 @@
       },
       {
         name: '邹城', lat: 35.4051, lng: 116.9649,
-        country: '中国', firstVisitDate: '',
-        notes: '孟府孟庙旅行',
+        country: '中国', firstVisitDate: '约1996',
+        notes: '约1996年游孟庙',
         category: 'domestic'
       },
       {
         name: '曲阜', lat: 35.5963, lng: 116.9864,
-        country: '中国', firstVisitDate: '',
-        notes: '三孔旅行：孔庙/孔府/孔林',
+        country: '中国', firstVisitDate: '约2018',
+        notes: '约2018年游孔府',
         category: 'domestic'
       },
       {


### PR DESCRIPTION
## Summary

- correct the first recorded Jinan visit to 1998 and note the elementary-school trip to Baotu Spring
- record approximate 1997 visits to Mount Tai and Dai Temple
- record the approximate 1996 visit to Mencius Temple
- record the approximate 2018 visit to the Kong Family Mansion

## Why

These updates preserve more precise dates and destinations from Paco's personal travel recollections while explicitly marking uncertain years as approximate.

## Impact

The corresponding map popups now show the refined first-visit years and landmark details. Existing Changsha details on `master` remain unchanged.

## Validation

- `git diff --check`